### PR TITLE
Fix console handle inherit

### DIFF
--- a/AppJailLauncher/utils.cpp
+++ b/AppJailLauncher/utils.cpp
@@ -383,7 +383,7 @@ HRESULT CreateClientSocketWorker(
 
 	LPTSTR pszCommandLine = NULL;
 	PSID pSid = NULL;
-	DWORD dwCreationFlags = CREATE_SUSPENDED;
+	DWORD dwCreationFlags = CREATE_SUSPENDED | DETACHED_PROCESS;
 	DWORD dwCapabilitiesCount = 0;
 	DWORD dwAttributeListSize = 0;
 	LPPROC_THREAD_ATTRIBUTE_LIST AttributeList = NULL;


### PR DESCRIPTION
This commit prevents the child process to access the parent console by detaching it.
I will edit my post tomorrow to describe an escape using the console.