### PR TITLE
Fix compatibility issue with PowerShell

### DIFF
--- a/AppJailLauncher/utils.cpp
+++ b/AppJailLauncher/utils.cpp
@@ -383,7 +383,7 @@ HRESULT CreateClientSocketWorker(
 
 	LPTSTR pszCommandLine = NULL;
 	PSID pSid = NULL;
-	DWORD dwCreationFlags = CREATE_SUSPENDED | DETACHED_PROCESS;
+	DWORD dwCreationFlags = CREATE_SUSPENDED | CREATE_NEW_CONSOLE;
 	DWORD dwCapabilitiesCount = 0;
 	DWORD dwAttributeListSize = 0;
 	LPPROC_THREAD_ATTRIBUTE_LIST AttributeList = NULL;


### PR DESCRIPTION
The previous PR #8 introduces a regression issue (PowerShell not working) so this commit fixes the issue by changing the process creation flag to `CREATE_NEW_CONSOLE`.